### PR TITLE
Fix bug in finding index of the first object for a label

### DIFF
--- a/application_to_galaxy_images.ipynb
+++ b/application_to_galaxy_images.ipynb
@@ -391,7 +391,7 @@
    "outputs": [],
    "source": [
     "label_id_to_find = 2\n",
-    "first_img_with_label = labels_all[np.where(labels_all==label_id_to_find)][0]\n",
+    "first_img_with_label = np.where(labels_all==label_id_to_find)[0][0]\n",
     "plt.imshow(images_4d[first_img_with_label]);\n",
     "plt.title(galaxy10cls_lookup(labels_all[first_img_with_label]));"
    ]


### PR DESCRIPTION
I noticed something was weird when changing `label_id_to_find` was giving repeated labels (it was using the label itself as the index)